### PR TITLE
Fix depended component archive missing

### DIFF
--- a/KOTORModSync.Core/Component.cs
+++ b/KOTORModSync.Core/Component.cs
@@ -214,7 +214,6 @@ namespace KOTORModSync.Core
             }
 
             // Validate and log additional errors/warnings.
-            Validator = new ComponentValidation( this );
             _ = Logger.LogAsync( $"Successfully deserialized component '{Name}'" );
         }
 

--- a/KOTORModSync.Core/ComponentValidation.cs
+++ b/KOTORModSync.Core/ComponentValidation.cs
@@ -224,33 +224,14 @@ namespace KOTORModSync.Core
 
                     if ( !File.Exists( realSourcePath ) )
                     {
-                        // download isn't required if the dependency mod isn't selected for install.
-                        if ( instruction.Dependencies?.Count != 0
-                            && instruction.Dependencies != null )
+                        if ( Component.ShouldRunInstruction( instruction, ComponentsList ))
                         {
-                            bool selectedForInstall = false;
-                            foreach ( Guid dependencyGuid in instruction.Dependencies )
-                            {
-                                Component dependencyComponent = Component.FindComponentFromGuid( dependencyGuid, ComponentsList );
-                                if ( !dependencyComponent.IsSelected )
-                                {
-                                    continue;
-                                }
-
-                                selectedForInstall = true;
-                                break;
-                            }
-
-                            if ( selectedForInstall )
-                            {
-                                continue;
-                            }
+                            AddError(
+                                "Missing required download:" + $" '{Path.GetFileName( realSourcePath )}'",
+                                instruction
+                            );
                         }
 
-                        AddError(
-                            "Missing required download:" + $" '{Path.GetFileNameWithoutExtension( realSourcePath )}'",
-                            instruction
-                        );
                         continue;
                     }
 

--- a/KOTORModSync.Core/ComponentValidation.cs
+++ b/KOTORModSync.Core/ComponentValidation.cs
@@ -24,10 +24,12 @@ namespace KOTORModSync.Core
 
         private readonly List<ValidationResult> _validationResults;
         public readonly Component Component;
+        public readonly List<Component> ComponentsList;
 
-        public ComponentValidation( Component component )
+        public ComponentValidation( Component component, List<Component> componentsList )
         {
             Component = component;
+            ComponentsList = componentsList;
             _validationResults = new List<ValidationResult>();
         }
 
@@ -222,6 +224,29 @@ namespace KOTORModSync.Core
 
                     if ( !File.Exists( realSourcePath ) )
                     {
+                        // download isn't required if the dependency mod isn't selected for install.
+                        if ( instruction.Dependencies?.Count != 0
+                            && instruction.Dependencies != null )
+                        {
+                            bool selectedForInstall = false;
+                            foreach ( Guid dependencyGuid in instruction.Dependencies )
+                            {
+                                Component dependencyComponent = Component.FindComponentFromGuid( dependencyGuid, ComponentsList );
+                                if ( !dependencyComponent.IsSelected )
+                                {
+                                    continue;
+                                }
+
+                                selectedForInstall = true;
+                                break;
+                            }
+
+                            if ( selectedForInstall )
+                            {
+                                continue;
+                            }
+                        }
+
                         AddError(
                             "Missing required download:" + $" '{Path.GetFileNameWithoutExtension( realSourcePath )}'",
                             instruction

--- a/KOTORModSync.Core/ComponentValidation.cs
+++ b/KOTORModSync.Core/ComponentValidation.cs
@@ -222,20 +222,23 @@ namespace KOTORModSync.Core
                         continue;
                     }
 
-                    if ( !File.Exists( realSourcePath ) )
+                    if ( File.Exists( realSourcePath ) )
                     {
-                        if ( Component.ShouldRunInstruction( instruction, ComponentsList ))
-                        {
-                            AddError(
-                                "Missing required download:" + $" '{Path.GetFileName( realSourcePath )}'",
-                                instruction
-                            );
-                        }
-
+                        allArchives.Add( realSourcePath );
                         continue;
                     }
 
-                    allArchives.Add( realSourcePath );
+                    if ( !Component.ShouldRunInstruction( instruction, ComponentsList ) )
+                    {
+                        continue;
+                    }
+
+                    AddError(
+                        "Missing required download:" + $" '{Path.GetFileName( realSourcePath )}'",
+                        instruction
+                    );
+
+                    continue;
                 }
             }
 

--- a/KOTORModSync.GUI/MainWindow.axaml.cs
+++ b/KOTORModSync.GUI/MainWindow.axaml.cs
@@ -861,7 +861,7 @@ namespace KOTORModSync
                 string name = _currentComponent.Name; // use correct name even if user clicks another component.
                 if ( name == null )
                 {
-                    throw new ArgumentNullException( nameof( name ), "Component does not have a valid 'Name' field." );
+                    throw new NullReferenceException( "Component does not have a valid 'Name' field." );
                 }
 
                 bool? confirm = await ConfirmationDialog.ShowConfirmationDialog(

--- a/KOTORModSync.GUI/MainWindow.axaml.cs
+++ b/KOTORModSync.GUI/MainWindow.axaml.cs
@@ -859,6 +859,10 @@ namespace KOTORModSync
                 }
 
                 string name = _currentComponent.Name; // use correct name even if user clicks another component.
+                if ( name == null )
+                {
+                    throw new ArgumentNullException( nameof( name ), "Component does not have a valid 'Name' field." );
+                }
 
                 bool? confirm = await ConfirmationDialog.ShowConfirmationDialog(
                     this,
@@ -875,7 +879,7 @@ namespace KOTORModSync
 
 
 
-                var validator = new ComponentValidation( _currentComponent );
+                var validator = new ComponentValidation( _currentComponent, ComponentsList );
                 await Logger.LogVerboseAsync( $" == Validating '{name}' == " );
                 if ( !validator.Run() )
                 {

--- a/KOTORModSync.GUI/MainWindow.axaml.cs
+++ b/KOTORModSync.GUI/MainWindow.axaml.cs
@@ -654,7 +654,7 @@ namespace KOTORModSync
                         individuallyValidated = false;
                     }
 
-                    var validator = new ComponentValidation( component );
+                    var validator = new ComponentValidation( component, ComponentsList );
                     await Logger.LogVerboseAsync( $" == Validating '{component.Name}' == " );
                     individuallyValidated &= validator.Run();
                 }


### PR DESCRIPTION
If a mod is selected that relies on archives in an instruction, but that instruction itself depends on another component that is NOT selected, currently the validators will say that the user is missing a required download. This will also happen with the instruction's restrictions. This PR fixes both of these scenarios.