### PR TITLE
Use MakeExecutableAsync to avoid issues when using HoloPatcher on *nix

### DIFF
--- a/KOTORModSync.GUI/MainWindow.axaml.cs
+++ b/KOTORModSync.GUI/MainWindow.axaml.cs
@@ -1491,16 +1491,16 @@ namespace KOTORModSync
 							"HoloPatcher could not be found in the Resources directory. Please ensure your AV isn't quarantining it and the file exists.");
 					}
 
-					//await Logger.LogVerboseAsync("Ensuring the holopatcher binary has executable permissions...");
-					//try
-					//{
-					//	await PlatformAgnosticMethods.MakeExecutableAsync(patcherCliPath);
-					//}
-					//catch ( Exception e )
-					//{
-					//	await Logger.LogExceptionAsync(e);
-					//	holopatcherIsExecutable = false;
-					//}
+					await Logger.LogVerboseAsync("Ensuring the holopatcher binary has executable permissions...");
+					try
+					{
+						await PlatformAgnosticMethods.MakeExecutableAsync(patcherCliPath);
+					}
+					catch ( Exception e )
+					{
+						await Logger.LogExceptionAsync(e);
+						holopatcherIsExecutable = false;
+					}
 
 					(int, string, string) result = await PlatformAgnosticMethods.ExecuteProcessAsync(
 						patcherCliPath.FullName,


### PR DESCRIPTION
Currently due to HoloPatcher being packaged in a zip for Linux and macOS, the executable bit is lost.

This means that users will have to go out of their way to set the included HoloPatcher binary as executable. This uncomments the code that did this previously (but must have been forgotten)

If this was intentional, it may make sense to ensure that HoloPatcher is stored in a tarball so that the executable bit is not lost when it is archived.