### PR TITLE
Fix CI Testing

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -100,7 +100,7 @@ jobs:
       id: generate-date
       run: |
         $date = Get-Date -Format yyyy-MM-dd
-        echo "::set-output name=date::$date"
+        Add-Content $env:GITHUB_OUTPUT ("date=$date")
 
     - name: Upload summary
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -57,17 +57,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
 
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
 
     - name: Execute unit tests
       run: |
@@ -82,7 +82,7 @@ jobs:
         trx2junit "TestResults/test_results_$date.xml" --output "TestResults/summary_$date.xml"
 
     - name: Modify test results XML
-      uses: actions/github-script@v4
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -103,7 +103,7 @@ jobs:
         echo "::set-output name=date::$date"
 
     - name: Upload summary
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Test Summary
         path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,15 +18,15 @@ defaults:
 
 jobs:
   lint_csharp:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set remote URL
       run: git remote set-url origin "https://github.com/${{ env.GITHUB_REPOSITORY }}.git"
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x' # SDK Version to use;
 


### PR DESCRIPTION
Updates GitHub Actions workflows to use latest action versions. 

This should solve issues with uploading artefacts and other deprecation warnings.