### PR TITLE
Complete markdown RenderMarkdownToString TODO with plain-text extraction

### DIFF
--- a/src/KOTORModSync.GUI/Converters/MarkdownRenderer.cs
+++ b/src/KOTORModSync.GUI/Converters/MarkdownRenderer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Avalonia;
@@ -275,6 +276,132 @@ namespace KOTORModSync.Converters
             }
 
             return new SolidColorBrush(Color.FromRgb(0x00, 0x00, 0x00)); // Light theme default
+        }
+
+        /// <summary>
+        /// Converts markdown to plain text: strips link syntax (keeping link text), bold/italic markers,
+        /// heading prefixes, and warning block delimiters. Line breaks are normalized to <see cref="Environment.NewLine"/>.
+        /// </summary>
+        [NotNull]
+        public static string MarkdownToPlainText([CanBeNull] string markdownText)
+        {
+            if (string.IsNullOrWhiteSpace(markdownText))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                string[] lines = markdownText.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                var output = new StringBuilder();
+                bool inWarningBlock = false;
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string rawLine = lines[i];
+                    string lineTrimEnd = rawLine.TrimEnd();
+                    string lineTrim = lineTrimEnd.Trim();
+
+                    if (inWarningBlock)
+                    {
+                        if (string.Equals(lineTrim, ":::", StringComparison.Ordinal))
+                        {
+                            inWarningBlock = false;
+                            continue;
+                        }
+
+                        AppendPlainLine(output, StripInlineMarkdown(lineTrimEnd));
+                        continue;
+                    }
+
+                    if (lineTrim.StartsWith(":::warning", StringComparison.OrdinalIgnoreCase))
+                    {
+                        inWarningBlock = true;
+                        string titlePart = lineTrim.Length > ":::warning".Length
+                            ? lineTrim.Substring(":::warning".Length).Trim()
+                            : string.Empty;
+                        if (!string.IsNullOrEmpty(titlePart))
+                        {
+                            AppendPlainLine(output, StripInlineMarkdown(titlePart));
+                        }
+
+                        continue;
+                    }
+
+                    if (lineTrim.StartsWith("#", StringComparison.Ordinal))
+                    {
+                        int level = 0;
+                        while (level < lineTrim.Length && lineTrim[level] == '#')
+                        {
+                            level++;
+                        }
+
+                        string headingBody = lineTrim.Substring(level).Trim();
+                        if (!string.IsNullOrEmpty(headingBody))
+                        {
+                            AppendPlainLine(output, StripInlineMarkdown(headingBody));
+                        }
+
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(lineTrimEnd))
+                    {
+                        continue;
+                    }
+
+                    AppendPlainLine(output, StripInlineMarkdown(lineTrimEnd));
+                }
+
+                return output.ToString().TrimEnd();
+            }
+            catch (Exception)
+            {
+                return markdownText;
+            }
+        }
+
+        private static void AppendPlainLine(StringBuilder output, string line)
+        {
+            if (output.Length > 0)
+            {
+                output.Append(Environment.NewLine);
+            }
+
+            output.Append(line);
+        }
+
+        /// <summary>
+        /// Strips <c>[text](url)</c>, <c>**bold**</c>, <c>__bold__</c>, and single-<c>*</c>/<c>_</c> italic spans
+        /// (same subset as <see cref="ParseMarkdownInlines"/>).
+        /// </summary>
+        private static string StripInlineMarkdown(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            string withLinks = Regex.Replace(
+                text,
+                @"\[([^\]]+)\]\(([^)]+)\)",
+                m => m.Groups[1].Value,
+                RegexOptions.Compiled,
+                TimeSpan.FromSeconds(5));
+
+            string noBold = Regex.Replace(
+                withLinks,
+                @"(\*\*|__)([^*_]+)\1",
+                m => m.Groups[2].Value,
+                RegexOptions.Compiled,
+                TimeSpan.FromSeconds(5));
+
+            return Regex.Replace(
+                noBold,
+                @"(\*|_)([^*_]+)\1",
+                m => m.Groups[2].Value,
+                RegexOptions.Compiled,
+                TimeSpan.FromSeconds(5));
         }
 
         [NotNull]

--- a/src/KOTORModSync.GUI/Services/MarkdownRenderingService.cs
+++ b/src/KOTORModSync.GUI/Services/MarkdownRenderingService.cs
@@ -95,9 +95,7 @@ namespace KOTORModSync.Services
                     return string.Empty;
                 }
 
-                // TODO - STUB: For now, just return the markdown content as-is since TextBlock can handle it
-                // The actual rendering happens when it's assigned to TextBlock.Inlines
-                return markdownContent;
+                return MarkdownRenderer.MarkdownToPlainText(markdownContent);
             }
             catch (Exception ex)
             {

--- a/src/KOTORModSync.Tests/MarkdownRendererPlainTextTests.cs
+++ b/src/KOTORModSync.Tests/MarkdownRendererPlainTextTests.cs
@@ -1,0 +1,61 @@
+// Copyright 2021-2025 KOTORModSync
+// Licensed under the Business Source License 1.1 (BSL 1.1).
+// See LICENSE.txt file in the project root for full license information.
+
+using KOTORModSync.Converters;
+using KOTORModSync.Services;
+
+using NUnit.Framework;
+
+namespace KOTORModSync.Tests
+{
+    [TestFixture]
+    public sealed class MarkdownRendererPlainTextTests
+    {
+        [Test]
+        public void MarkdownToPlainText_Link_KeepsLinkTextOnly()
+        {
+            string result = MarkdownRenderer.MarkdownToPlainText("See [docs](https://example.com) here.");
+            Assert.That(result, Is.EqualTo("See docs here."));
+        }
+
+        [Test]
+        public void MarkdownToPlainText_BoldAndItalic_StripsMarkers()
+        {
+            string result = MarkdownRenderer.MarkdownToPlainText("**bold** and *italic*");
+            Assert.That(result, Is.EqualTo("bold and italic"));
+        }
+
+        [Test]
+        public void MarkdownToPlainText_Heading_StripsHashPrefix()
+        {
+            string result = MarkdownRenderer.MarkdownToPlainText("## Section title");
+            Assert.That(result, Is.EqualTo("Section title"));
+        }
+
+        [Test]
+        public void MarkdownToPlainText_WarningBlock_StripsDelimiters()
+        {
+            const string md = @":::warning Heads up
+Body line
+:::
+After";
+            string result = MarkdownRenderer.MarkdownToPlainText(md);
+            Assert.That(
+                result,
+                Is.EqualTo(
+                    "Heads up"
+                    + System.Environment.NewLine
+                    + "Body line"
+                    + System.Environment.NewLine
+                    + "After"));
+        }
+
+        [Test]
+        public void RenderMarkdownToString_DelegatesToPlainTextExtraction()
+        {
+            string result = MarkdownRenderingService.RenderMarkdownToString("[x](y)");
+            Assert.That(result, Is.EqualTo("x"));
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the `// TODO - STUB` in `MarkdownRenderingService.RenderMarkdownToString` by implementing real plain-text extraction instead of returning raw markdown.

## Changes

- **`MarkdownRenderer.MarkdownToPlainText`**: Strips the same inline constructs the UI renderer understands (`[text](url)`, `**bold**` / `__bold__`, `*italic*` / `_italic_`), removes `#` heading prefixes, and unwraps `:::warning` blocks (title + body, closing `:::`).
- **`RenderMarkdownToString`**: Delegates to `MarkdownToPlainText`.
- **Tests**: `MarkdownRendererPlainTextTests` (NUnit) cover links, bold/italic, headings, warning blocks, and the service wrapper.

## Testing

`dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj --filter "FullyQualifiedName~MarkdownRendererPlainTextTests"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12029a4b-f321-4534-9d16-6b6e32a6d86c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12029a4b-f321-4534-9d16-6b6e32a6d86c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

