### PR TITLE
docs: security audit report + updated cloud-agents-starter skill

### DIFF
--- a/.cursor/skills/cloud-agents-starter/SKILL.md
+++ b/.cursor/skills/cloud-agents-starter/SKILL.md
@@ -11,185 +11,254 @@ A minimal runbook for Cloud agents covering practical setup, execution, and test
 
 ## 1. Initial Setup
 
+**Verify environment:**
+```bash
+git status -sb
+dotnet --info          # must be 9.0.x
+gh auth status         # read-only GitHub CLI usage
+```
+
 **Vendor dependencies (required before first build):**
 ```bash
 git submodule update --init --recursive
 ```
 
-**NuGet sources:** `NuGet.config` at repo root. Includes nuget.org and GitHub Packages.
+**NuGet sources:** `NuGet.config` at repo root. Only nuget.org is configured (the GitHub Packages feed `github-th3w1zard1` was removed in PR #65). No auth needed for public package restore.
 
 ---
 
-## 2. GUI Application
+## 2. Build
+
+```bash
+# Full solution
+dotnet build KOTORModSync.sln --configuration Debug
+
+# GUI project only
+dotnet build src/KOTORModSync.GUI/KOTORModSync.csproj
+
+# Core CLI project only (also usable standalone via dotnet run)
+dotnet build src/KOTORModSync.Core/KOTORModSync.Core.csproj -f net9.0
+```
+
+---
+
+## 3. GUI Application (`src/KOTORModSync.GUI`)
 
 **Entry point:** `src/KOTORModSync.GUI/Program.cs` (Avalonia UI)
 
-**Build and run:**
+**Cloud agents are headless — do NOT run the GUI.** Use automated tests instead.
+
+For local desktop runs (requires `DISPLAY=:1`):
 ```bash
-# From repo root
-dotnet build src/KOTORModSync.GUI/KOTORModSync.csproj
-dotnet run --project src/KOTORModSync.GUI/KOTORModSync.csproj
+dotnet run --project src/KOTORModSync.GUI/KOTORModSync.csproj --configuration Debug --framework net9.0
 ```
 
-**CLI args (from `src/KOTORModSync.GUI/CLIArguments.cs`):**
-- `--kotorPath="C:\Path\To\Game"`
-- `--modDirectory="C:\Path\To\Mods"`
-- `--instructionFile="C:\Path\To\Instructions.toml"`
-
-**Linux/WSL:** Install X11 libs first if needed:
+**Preload CLI args** (avoid file-picker interaction):
 ```bash
-sudo apt install libsm6 libice6 libx11-dev libfontconfig1 libx11-6 libx11-xcb1 libxau6 libxcb1 libxdmcp6 libxcb-xkb1 libxcb-render0 libxcb-shm0 libxcb-xfixes0 libxcb-util1 libxcb-xinerama0 libxcb-randr0 libxcb-image0 libxcb-keysyms1 libxcb-sync1 libxcb-xtest0
-```
-Set `DISPLAY=` to avoid X11 waits in headless or CI environments.
-
-**Launch profiles:** `src/KOTORModSync.GUI/Properties/launchSettings.json` — profiles: `dotnet`, `dotnetframework`, `WSL`.
-
----
-
-## 3. Core CLI (ModBuildConverter)
-
-**Entry point:** `src/KOTORModSync.Core/` — run via `ModBuildConverter.Run(args)` (exposed by Tests project for CLI use).
-
-**Run Core verbs:**
-```bash
-dotnet run --project src/KOTORModSync.Core/KOTORModSync.Core.csproj --framework net9.0 -- <verb> [options]
+dotnet run ... -- \
+  --instructionFile=./mod-builds/TOMLs/KOTOR1_Full.toml \
+  --kotorPath=./tmp/kotor_template \
+  --modDirectory=./tmp/mod_downloads
 ```
 
-**Common verbs:** `convert`, `merge`, `validate`, `install`, `set-nexus-api-key`, `install-python-deps`, `holopatcher`, `cache-stats`, `cache-clear`, `cache-block`, `cache-test`, `cache-seed`.
-
-**Example:**
+**Helper scripts (prefer these over ad hoc commands):**
 ```bash
-dotnet run --project src/KOTORModSync.Core/KOTORModSync.Core.csproj -- validate -i path/to/instructions.toml
+./scripts/agents/create_template_kotor_install.sh ./tmp/kotor_template ./tmp/mod_downloads
+./scripts/agents/ensure_linux_holopatcher.sh
+./scripts/agents/launch_gui_desktop.sh \
+  --instruction-file ./mod-builds/TOMLs/KOTOR1_Full.toml \
+  --kotor-dir ./tmp/kotor_template \
+  --mod-dir ./tmp/mod_downloads
 ```
 
 ---
 
-## 4. Testing
+## 4. Core CLI (`src/KOTORModSync.Core`)
 
-**Project:** `src/KOTORModSync.Tests/KOTORModSync.Tests.csproj`  
-**Do not create additional test projects.** All tests live here (NUnit, xUnit, Moq, Avalonia.Headless.XUnit).
+**Common verbs:** `convert`, `merge`, `validate`, `install`, `set-nexus-api-key`, `cache-stats`, `cache-clear`, `cache-test`, `cache-seed`.
 
-**Test project paths (from repo root):**
-- `src/KOTORModSync.Tests/KOTORModSync.Tests.csproj`
-
-### Run commands
-
-**All unit tests:**
 ```bash
-dotnet build -c Release
-dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj -c Release --no-build --verbosity normal
+dotnet run --project src/KOTORModSync.Core/KOTORModSync.Core.csproj --framework net9.0 -- \
+  validate -i path/to/instructions.toml
 ```
 
-**DistributedCache tests only** (exclude long and seeding):
+**Best-effort install (CI automation):**
+```bash
+./scripts/agents/install_best_effort.sh ./mod-builds/TOMLs/KOTOR1_Full.toml ./tmp/game ./tmp/mods
+```
+
+---
+
+## 5. Testing
+
+**All tests live in one project:** `src/KOTORModSync.Tests/KOTORModSync.Tests.csproj`  
+**Do not create additional test projects.**
+
+### Standard Cloud / headless test run
+
+Excludes long-running and seeding tests, and distributed cache:
+```bash
+dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj \
+  --filter "FullyQualifiedName!~LongRunning&FullyQualifiedName!~GitHubRunnerSeeding&FullyQualifiedName!~DistributedCache" \
+  --configuration Debug
+```
+
+### Distributed cache tests (separate filter required)
+
 ```bash
 dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj \
   --filter "FullyQualifiedName~DistributedCache&FullyQualifiedName!~LongRunning&FullyQualifiedName!~GitHubRunnerSeeding"
 ```
 
-**Single test (with timeout):**
-```bash
-dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj \
-  --filter "FullyQualifiedName~<test_name>" --no-build
-```
+### Single test with 120-second timeout (PowerShell — required by .cursorrules)
 
-**Documentation round-trip tests** (mod-build validation):
-```bash
-TEST_FILE_PATH=test_modbuild_current.md dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj \
-  --filter "FullyQualifiedName~DocumentationRoundTripTests" --no-build
+```pwsh
+pwsh -Command '& {
+  $proj = "src/KOTORModSync.Tests/KOTORModSync.Tests.csproj"
+  $args = "test {0} --filter ""FullyQualifiedName~<TestName>"" --list-tests" -f $proj
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = "dotnet"
+  $psi.Arguments = $args
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $psi.UseShellExecute = $false
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $psi
+  $null = $process.Start()
+  if (-not $process.WaitForExit(120000)) {
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.Kill()
+    $process.WaitForExit()
+    Write-Output $stdout
+    Write-Output $stderr
+    Write-Output "--- COMMAND TIMED OUT AFTER 120s ---"
+  } else {
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    Write-Output $stdout
+    Write-Output $stderr
+  }
+}'
 ```
 
 ### Test naming conventions
 
-| Suffix | Purpose |
-|--------|---------|
-| `GitHubRunnerSeeding` | 5–6 hour seeding tests, only for GitHub Actions |
-| `LongRunning` | >2 min, excluded from normal runs |
-| (none) | Regular tests, <2 min |
+| Suffix | Purpose | Max duration |
+|--------|---------|--------------|
+| `GitHubRunnerSeeding` | GitHub Actions seeding only | 5–6 hours |
+| `LongRunning` | Local long tests, not for GitHub runners | >2 minutes |
+| (none) | Regular tests | <2 minutes |
 
-### Test runsettings
+### Known expected failures on Cloud VMs
 
-`src/KOTORModSync.Tests/KOTORModSync.Tests.runsettings` — excludes `Slow` tests.
+- `CrossPlatformFileWatcherTests` — inotify not available in container FS; pre-existing, ignore.
+- Some Avalonia headless xUnit tests — headless display support limitations; pre-existing, ignore.
+
+### Tests by codebase area
+
+| Area | Filter |
+|------|--------|
+| Path sandboxing / zip-slip | `FullyQualifiedName~PathHelperArchiveExtractionTests` |
+| URL scheme security | `FullyQualifiedName~UrlUtilitiesSecurityTests` |
+| Settings file permissions | `FullyQualifiedName~SettingsFilePermissionsTests` |
+| Markdown renderer | `FullyQualifiedName~MarkdownRendererPlainTextTests` |
+| Install coordinator | `FullyQualifiedName~InstallCoordinatorTests` |
+| Download queue | `FullyQualifiedName~DownloadQueueHeadlessTests` |
+| Auto-update service | `FullyQualifiedName~AutoUpdateServiceTests` |
+| Telemetry | `Name~ComputeSignature_SameInputs_ReturnsDeterministicLowercaseHex` |
 
 ---
 
-## 5. Feature Flags & Build Constants
+## 6. Feature Flags & Build Constants
 
-**No runtime feature-flag system.** Behavior is controlled by build-time preprocessor defines.
+No runtime feature-flag system. Behavior is controlled by build-time preprocessor defines.
 
 | Define | Effect |
 |--------|--------|
 | `OFFICIAL_BUILD` | Enables embedded telemetry signing key in release builds |
 
-**Enable `OFFICIAL_BUILD`:**
 ```bash
+# Enable OFFICIAL_BUILD (release pipeline only — never for dev/PR builds)
 dotnet build -c Release /p:DefineConstants="OFFICIAL_BUILD"
 ```
-Omit for PRs and dev builds.
-
-**Disable telemetry (no `OFFICIAL_BUILD`):** Build without this define; telemetry falls back to env/file and can be left unset.
 
 ---
 
-## 6. Auth / Telemetry
+## 7. Auth / Telemetry
 
-**No user login.** Telemetry uses HMAC auth.
+**No user login.** Telemetry uses HMAC auth. Defaults to **disabled** until the user explicitly consents on first run.
 
 **Client signing secret (order of precedence):**
 1. `KOTORMODSYNC_SIGNING_SECRET` env var
 2. `{ApplicationData}/KOTORModSync/telemetry.key`
-3. `EmbeddedSecrets.TELEMETRY_SIGNING_KEY` (only when `OFFICIAL_BUILD`)
+3. `EmbeddedSecrets.TELEMETRY_SIGNING_KEY` (only when `OFFICIAL_BUILD`; file is gitignored)
 
-**Telemetry auth service** (`telemetry-auth/`): HMAC validation for OpenTelemetry.  
-**Disable auth (service):** `REQUIRE_AUTH=false` when running the service.
+**Telemetry consent:** Must be `IsEnabled=true` AND `UserConsented=true` in `telemetry_config.json`. Default is both `false`.
 
 ---
 
-## 7. Environment Variables
+## 8. Environment Variables
 
 | Variable | Purpose |
 |----------|---------|
 | `KOTORMODSYNC_SIGNING_SECRET` | Telemetry HMAC signing secret |
+| `KOTORMODSYNC_RELAY_CREDENTIAL` | Relay auth credential (format: `user:pass`); default falls back to `admin:adminadmin` for local test Docker |
+| `KOTOR_MODSYNC_NEXUS_API_KEY` | Nexus Mods API key (also: `NEXUS_MODS_API_KEY`) |
+| `REQUIRE_AUTH=false` | Disable auth validation in telemetry-auth service (local testing) |
 | `NCS_INTERPRETER_DEBUG` | HoloPatcher NCS interpreter debug (`true` to enable) |
-| `NCSDecomp_DEBUG_STACK` | NCS decompiler debug (Java stubs) |
-| `TEST_FILE_PATH` | Path to mod-build test file (e.g. mod-build-validation workflow) |
 | `PYTHON_KEYRING_BACKEND` | Set to `keyring.backends.null.Keyring` to avoid pip hangs |
-| `DISPLAY` | Set empty in headless/CI to avoid X11 waits |
+| `DISPLAY` | Set to `:1` for Linux desktop GUI; do NOT clear/empty it (needed by child tools) |
 
 ---
 
-## 8. Configuration Files
+## 9. Configuration Files
 
 | Path | Purpose |
 |------|---------|
 | `{ApplicationData}/KOTORModSync/settings.json` | GUI preferences, paths, Nexus API key |
 | `{ApplicationData}/KOTORModSync/telemetry_config.json` | Telemetry options |
 | `{ApplicationData}/KOTORModSync/telemetry.key` | Signing secret fallback |
-| `testenvironments.json` | WSL/Ubuntu test environment config |
+| `NuGet.config` | Package sources (nuget.org only) |
 
 ---
 
-## 9. Quick Reference
+## 10. Security Notes for Code Changes
+
+When modifying auth, settings, or telemetry code, keep these invariants:
+
+- **Never log the full settings JSON**: `LoadSettings` logs the raw JSON at verbose level which includes `nexusModsApiKey`. When adding new secret-bearing fields to `AppSettings`, strip them from the verbose log.
+- **Never embed secrets in log messages**: Only log that a key was loaded, never its value.
+- **URL scheme allow-list**: `UrlUtilities.OpenUrl` and `OpenLinkConverter` only allow `https://`, `http://`, and `mailto:`. Do not add new schemes without security review.
+- **Archive entry paths**: All archive extraction must go through `PathHelper.TryGetZipSafeArchiveEntryExtractPath` to prevent zip-slip.
+- **SFX execution guard**: Before executing an `.exe` as a 7z SFX, verify it has the MZ PE header via `ArchiveHelper.IsPotentialSevenZipSFX`.
+- **Telemetry consent**: `TelemetryService.Initialize()` requires both `IsEnabled` and `UserConsented` to be true.
+- **Relay credential**: Production relay deployments must set `KOTORMODSYNC_RELAY_CREDENTIAL`. The fallback `admin:adminadmin` is for local Docker containers only.
+- **Settings file permissions**: On Unix, `settings.json` must be `chmod 600` (owner-read/write only) to protect the Nexus API key.
+
+---
+
+## 11. Quick Reference
 
 | Task | Command |
 |------|---------|
 | Init submodules | `git submodule update --init --recursive` |
-| Build GUI | `dotnet build src/KOTORModSync.GUI/KOTORModSync.csproj` |
-| Run GUI | `dotnet run --project src/KOTORModSync.GUI/KOTORModSync.csproj` |
-| Run Core CLI | `dotnet run --project src/KOTORModSync.Core/KOTORModSync.Core.csproj -- <verb> [options]` |
-| Run all tests | `dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj -c Release` |
+| Build solution | `dotnet build KOTORModSync.sln --configuration Debug` |
+| Run Core CLI | `dotnet run --project src/KOTORModSync.Core/KOTORModSync.Core.csproj --framework net9.0 -- <verb>` |
+| Run standard tests | `dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj --filter "FullyQualifiedName!~LongRunning&FullyQualifiedName!~GitHubRunnerSeeding&FullyQualifiedName!~DistributedCache"` |
 | Run DistCache tests | `dotnet test src/KOTORModSync.Tests/KOTORModSync.Tests.csproj --filter "FullyQualifiedName~DistributedCache&FullyQualifiedName!~LongRunning&FullyQualifiedName!~GitHubRunnerSeeding"` |
 | Release build (with telemetry) | `dotnet build -c Release /p:DefineConstants="OFFICIAL_BUILD"` |
 
 ---
 
-## 10. Updating This Skill
+## 12. Updating This Skill
 
 When you discover new runbook steps or testing tricks:
 
 1. **Edit this file:** `.cursor/skills/cloud-agents-starter/SKILL.md`
-2. **Add to the right section** (or add a new section) with concrete commands.
-3. **Keep it minimal** — only practical, runnable instructions.
-4. **Use code blocks** for all commands.
-5. **Commit** the change so future Cloud agent runs pick it up.
+2. **Update the right section** with concrete, copy-pasteable commands.
+3. **Mirror changes** to `docs/local_desktop_agent_runbook.md` and related skills (`.cursor/skills/local_desktop_gui_testing/SKILL.md`, `.cursor/skills/full_build_install_validation/SKILL.md`).
+4. **If it's a hard rule for all tasks**, also add it to `.cursorrules`.
+5. **Commit** so future Cloud agent runs pick it up automatically.
 
-Optional subfolders: `scripts/`, `references/`, `assets/` for extra tooling or docs if needed.
+Keep it minimal — only practical, runnable instructions. No theory.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR delivers two outputs from the requested review:

1. **Security audit of the last 10 merged PRs** (findings below)
2. **Updated `.cursor/skills/cloud-agents-starter/SKILL.md`** with accurate setup/test/security instructions

---

## Security Audit: Last 10 Merged PRs

PRs reviewed (newest first): #67, #66, #65, #64, #63, #62, #61, #60, #59, #58

---

### PR #67 — Markdown `RenderMarkdownToString` TODO

**Verdict: No security issues.**

- Adds `MarkdownToPlainText` that strips link/bold/italic syntax using compiled regexes with 5-second timeouts — no ReDoS risk.
- `RenderMarkdownToString` now delegates to this function instead of returning raw markdown.

---

### PR #66 — Comprehensive security fixes

**Verdict: Resolves multiple previously-identified issues. One residual finding.**

**Fixes confirmed:**
- Relay credential moved from hardcoded `admin:adminadmin` to `KOTORMODSYNC_RELAY_CREDENTIAL` env var.
- Telemetry defaults changed to `IsEnabled=false, UserConsented=false`.
- `TelemetryService.Initialize()` now requires both `IsEnabled` AND `UserConsented`.
- `UrlUtilities.OpenUrl` now enforces an allow-list (`https`, `http`, `mailto`) and URI-escapes the URL before shell dispatch.
- `DownloadLinksControl.OpenLink_Click` also got scheme validation.
- `AppSettings.SaveSettings` now logs only JSON length (not the full JSON including the Nexus API key).
- Settings file gets `chmod 600` on Unix to protect the Nexus API key.
- First-run telemetry consent dialog is shown before any telemetry is initialized.

**Residual finding — MEDIUM severity:**

> **`AppSettings.LoadSettings` still logs the full raw JSON at verbose level (line 256)**
>
> ```csharp
> string json = File.ReadAllText(SettingsFilePath);
> Logger.LogVerbose($"[SettingsManager.LoadSettings] Read settings JSON: {json}");
> ```
>
> `settings.json` contains `nexusModsApiKey`. Anyone with access to verbose logs (which are written to disk) can read the Nexus API key in plaintext. `SaveSettings` was fixed in this PR to log only length, but `LoadSettings` was not updated.
>
> **Recommendation:** Replace line 256 with `Logger.LogVerbose($"[SettingsManager.LoadSettings] Read settings JSON length: {json.Length} chars");`

---

### PR #65 — CI flakiness fixes

**Verdict: No security issues; one note.**

- Removed `github-th3w1zard1` from `NuGet.config`.
- **Note:** `build-and-test.yml` still runs `dotnet nuget update source github-th3w1zard1 --store-password-in-clear-text` against the now-removed source. This step will no-op or warn but writes the `GITHUB_TOKEN` in plaintext to `NuGet.config` on the CI runner ephemeral filesystem. This is acceptable for GitHub-hosted runners (token is short-lived and the file is never uploaded), but the step is now dead code and could be removed.

---

### PR #64 — AGENTS.md updates

**Verdict: No security issues.**  
Documentation only (project layout, build command, Cursor Cloud instructions).

---

### PR #63 — Cloud agent starter skill (`cloud_agent_starter`)

**Verdict: No security issues.**  
New skill file with agent runbook. Documents `DISPLAY`, `REQUIRE_AUTH`, and `KOTORMODSYNC_SIGNING_SECRET` env vars correctly.

---

### PR #62 — Development environment setup

**Verdict: No security issues.**  
AGENTS.md additions only.

---

### PR #61 — Application functionality / CI

**Verdict: No security issues.**

- CI workflow now provisions `mod-builds` and `KPatcher` via `git clone`. Both are public repos; no credential exposure.
- `App.axaml.cs` stores `AutoUpdateService` in a field (previously a local, so it could be GC'd). Correct pattern.
- `DownloadProgressWindow.ResetForNewSession` clears download state lists — no security implications.

---

### PR #60 — Merged PRs security review

**Verdict: Introduced meaningful security fixes; one residual concern.**

**Fixes confirmed:**
- `PathHelper.TryGetZipSafeArchiveEntryExtractPath` added: explicit zip-slip/path-traversal guard for all archive extraction code paths (`RealFileSystemProvider`, `VirtualFileSystemProvider`, `ArchiveHelper.TryExtractSevenZipSfx`).
- `OpenLinkConverter` now validates URI scheme against `https/http/mailto` allow-list before shell dispatch.
- `mcp_desktop_commander.sh`, `mcp_filesystem.sh`, `mcp_playwright.sh` pinned to explicit versions (removes `@latest` supply-chain risk).

**Residual finding — MEDIUM severity (same relay credential as noted in PR #66):**

The hardcoded `admin:adminadmin` relay fallback was present in the merged code of this PR and only moved to env var in PR #66. As of the current `master` HEAD, PR #66's fix is in place.

---

### PR #59 — CLI install enhancements

**Verdict: No security issues.**

- `DISPLAY` environment variable blanking (`Environment.SetEnvironmentVariable("DISPLAY", "")`) was removed — correct, as it could break child processes that legitimately use X11.
- Nexus API key is loaded from `KOTOR_MODSYNC_NEXUS_API_KEY`/`NEXUS_MODS_API_KEY` env vars — key value is never logged, only a confirmation message.
- `--nexus-api-key` CLI flag: value is stored in config, verbose log only says "set from --nexus-api-key" (no value).

---

### PR #58 — CI workflow / lint fixes

**Verdict: No security issues.**

- TruffleHog pinned from `@main` to `@v3.88.2` — eliminates supply-chain risk from unpinned `@main` action.
- `--only-verified` flag kept, reducing false-positives without weakening coverage.

---

## Summary Table

| PR | Finding | Severity | Status |
|----|---------|----------|--------|
| #66 | `LoadSettings` logs full JSON including Nexus API key | Medium | **Open** |
| #65 | Dead `dotnet nuget update source github-th3w1zard1 --store-password-in-clear-text` CI step | Low | Open (dead code, no actual leak) |
| #58–#67 | All other diffs | — | No issue |

---

## Skill Update

Updated `.cursor/skills/cloud-agents-starter/SKILL.md`:

- Corrected NuGet.config note (GitHub Packages feed removed)
- Added test-by-area quick reference table
- Added Section 10 (Security Notes) documenting the invariants to preserve
- Documented `KOTORMODSYNC_RELAY_CREDENTIAL` env var
- Fixed `DISPLAY` guidance (do not clear; leave user session value intact)
- Synced test command paths to `src/` prefix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d0dfaf0-5aa7-4edd-9f0a-56ac60b89aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d0dfaf0-5aa7-4edd-9f0a-56ac60b89aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

